### PR TITLE
Manually trigger Github Action workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@
 ```yaml
 name: Latest blog post workflow
 on:
-  schedule:
-    # Runs every hour
-    - cron: '0 * * * *'
-
+  schedule: # Run workflow automatically
+    - cron: '0 * * * *' # Runs every hour, on the hour
+  workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
+    inputs:
+      git-ref:
+        description: Git Ref (Optional)    
+        required: false
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ name: Latest blog post workflow
 on:
   schedule: # Run workflow automatically
     - cron: '0 * * * *' # Runs every hour, on the hour
-  workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
-    inputs:
-      git-ref:
-        description: Git Ref (Optional)    
-        required: false
+  workflow_dispatch:
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ name: Latest blog post workflow
 on:
   schedule: # Run workflow automatically
     - cron: '0 * * * *' # Runs every hour, on the hour
-  workflow_dispatch:
+  workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts


### PR DESCRIPTION


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our contribution guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add a new way to trigger a workflow, which is manual, to avoid waiting for the automated (cron) trigger.

Here is what it creates from the workflow page:
![image](https://user-images.githubusercontent.com/3807458/92180501-7b7b7a80-ee47-11ea-9353-8b1931f78c59.png)

Notice the `Run workflow` button.

* **What is the current behavior?** (You can also link to an open issue here)

No way to trigger manually

* **What is the new behavior (if this is a feature change)?**

Both manual and automated (cron) triggers

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No


* **Other information**:
Use workflow_dispatch recent feature

See another example at https://github.community/t/github-actions-manual-trigger-approvals/16233/83